### PR TITLE
fix(terraform): add apex_domain* variables and deprecate parent_domain* variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,7 @@ module "jx" {
   max_node_count                  = var.max_node_count
   node_disk_size                  = var.node_disk_size
   node_disk_type                  = var.node_disk_type
+  apex_domain                     = var.apex_domain
   parent_domain                   = var.parent_domain
   tls_email                       = var.tls_email
   lets_encrypt_production         = var.lets_encrypt_production
@@ -19,6 +20,7 @@ module "jx" {
   jx_bot_token                    = var.jx_bot_token
   force_destroy                   = var.force_destroy
   subdomain                       = var.subdomain
+  apex_domain_gcp_project         = var.apex_domain_gcp_project
   parent_domain_gcp_project       = var.parent_domain_gcp_project
   apex_domain_integration_enabled = var.apex_domain_integration_enabled
 

--- a/variables.tf
+++ b/variables.tf
@@ -73,6 +73,13 @@ variable "parent_domain" {
   description = "The parent domain to be allocated to the cluster"
   type        = string
   default     = ""
+  deprecation = "Please use apex_domain variable instead."
+}
+
+variable "apex_domain" {
+  description = "The apex domain to be allocated to the cluster"
+  type        = string
+  default     = ""
 }
 
 variable "tls_email" {
@@ -118,6 +125,14 @@ variable "parent_domain_gcp_project" {
   description = "The GCP project the parent domain is managed by, used to write recordsets for a subdomain if set.  Defaults to current project."
   type        = string
   default     = ""
+  deprecation = "Please use apex_domain_gcp_project variable instead."
+}
+
+variable "apex_domain_gcp_project" {
+  description = "The GCP project the apex domain is managed by, used to write recordsets for a subdomain if set.  Defaults to current project."
+  type        = string
+  default     = ""
+
 }
 
 variable "apex_domain_integration_enabled" {


### PR DESCRIPTION
Related [slack thread](https://kubernetes.slack.com/archives/C9LTHT2BB/p1607443301111500)

More coherent with the TLS doc and the other gitops templates.